### PR TITLE
Cleanup the require() calling in controllers, templates, views and such.

### DIFF
--- a/app/controllers.js
+++ b/app/controllers.js
@@ -1,5 +1,0 @@
-// load all your controllers here
-
-require('controllers/application');
-require('controllers/home');
-require('controllers/bob');

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,0 +1,1 @@
+module.exports = require('require-dir')();

--- a/app/models.js
+++ b/app/models.js
@@ -1,3 +1,0 @@
-// load all your models here
-
-require('models/bob');

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -1,0 +1,1 @@
+module.exports = require('require-dir')();

--- a/app/templates.js
+++ b/app/templates.js
@@ -1,5 +1,0 @@
-// load all your templates here
-
-require('templates/application');
-require('templates/home');
-require('templates/bob');

--- a/app/templates/index.js
+++ b/app/templates/index.js
@@ -1,0 +1,1 @@
+module.exports = require('require-dir')();

--- a/app/views.js
+++ b/app/views.js
@@ -1,5 +1,0 @@
-// load all your views here
-
-require('views/application');
-require('views/home');
-require('views/bob');

--- a/app/views/index.js
+++ b/app/views/index.js
@@ -1,0 +1,1 @@
+module.exports = require('require-dir')();

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "css-brunch": ">= 1.0 < 1.5",
     "uglify-js-brunch": ">= 1.0 < 1.5",
     "clean-css-brunch": ">= 1.0 < 1.5",
-    "ember-handlebars-brunch": "git://github.com/icholy/ember-handlebars-brunch.git"
+    "ember-handlebars-brunch": "git://github.com/icholy/ember-handlebars-brunch.git",
+    "require-dir": "~0.1.0"
   },
   "devDependencies": {
     "mocha": "0.14.0",


### PR DESCRIPTION
This is untested/currently does not work (it does not find require-dir), but I think this is a good approach to doing things.

At the very least we should be using index.js files in the folders themselves instead of having a bunch of js files with the same name as the folders. require('controllers') will require controllers.js or the file in folder controller/index.js :-)

Anyway, using something like I suggest here we would have to re-type things a whole lot more.
