### PR TITLE
Add dependency on coffee-script-brunch so that .coffee files compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "javascript-brunch": ">= 1.0 < 1.5",
+    "coffee-script-brunch": ">= 1.0 < 1.5",
     "css-brunch": ">= 1.0 < 1.5",
     "uglify-js-brunch": ">= 1.0 < 1.5",
     "clean-css-brunch": ">= 1.0 < 1.5",


### PR DESCRIPTION
The README implies that simply adding .coffee files under app is enough to have coffeescript files work.

From my experience, I had to change packages.json and run npm install to have .coffee files be recognized.

Either this plugin needs to be added as a dependency (thus this pull request) or the README should be changed to outline the extra step to get coffeescript working.
